### PR TITLE
virts-2891 - Powershell error parsing

### DIFF
--- a/app/atomic_svc.py
+++ b/app/atomic_svc.py
@@ -292,6 +292,9 @@ class AtomicService(BaseService):
                 command, cleanup, payloads = await self._prepare_executor(test, platform, executor)
                 data['platforms'][platform] = dict()
                 data['platforms'][platform][executor] = dict(command=command, payloads=payloads, cleanup=cleanup)
+                if executor == 'psh':
+                    data['platforms'][platform][executor]['parsers'] = {'plugins.atomic.app.parsers.powershell':
+                                                                           [{'source': 'validate_me'}]}
 
         if data['platforms']:  # this might be empty, if so there's nothing useful to save
             d = os.path.join(self.data_dir, 'abilities', tactic)

--- a/app/atomic_svc.py
+++ b/app/atomic_svc.py
@@ -294,7 +294,7 @@ class AtomicService(BaseService):
                 data['platforms'][platform][executor] = dict(command=command, payloads=payloads, cleanup=cleanup)
                 if executor == 'psh':
                     data['platforms'][platform][executor]['parsers'] = {'plugins.atomic.app.parsers.powershell':
-                                                                           [{'source': 'validate_me'}]}
+                                                                        [{'source': 'validate_me'}]}
 
         if data['platforms']:  # this might be empty, if so there's nothing useful to save
             d = os.path.join(self.data_dir, 'abilities', tactic)

--- a/app/atomic_svc.py
+++ b/app/atomic_svc.py
@@ -293,7 +293,7 @@ class AtomicService(BaseService):
                 data['platforms'][platform] = dict()
                 data['platforms'][platform][executor] = dict(command=command, payloads=payloads, cleanup=cleanup)
                 if executor == 'psh':
-                    data['platforms'][platform][executor]['parsers'] = {'plugins.atomic.app.parsers.powershell':
+                    data['platforms'][platform][executor]['parsers'] = {'plugins.atomic.app.parsers.atomic_powershell':
                                                                         [{'source': 'validate_me'}]}
 
         if data['platforms']:  # this might be empty, if so there's nothing useful to save

--- a/app/parsers/atomic_powershell.py
+++ b/app/parsers/atomic_powershell.py
@@ -3,10 +3,11 @@ from app.utility.base_parser import BaseParser, PARSER_SIGNALS_FAILURE
 
 
 class Parser(BaseParser):
+    checked_flags = list('FullyQualifiedErrorId')
 
     def parse(self, blob):
         for ex_line in self.line(blob):
-            if 'FullyQualifiedErrorId' in ex_line:
+            if any(x in ex_line for x in self.checked_flags):
                 log = logging.getLogger('parsing_svc')
                 log.warning('This ability failed for some reason. Manually updating the link to report a failed state.')
                 return [PARSER_SIGNALS_FAILURE]

--- a/app/parsers/powershell.py
+++ b/app/parsers/powershell.py
@@ -5,8 +5,8 @@ from app.utility.base_parser import BaseParser, PARSER_SIGNALS_FAILURE
 class Parser(BaseParser):
 
     def parse(self, blob):
-        for l in self.line(blob):
-            if 'FullyQualifiedErrorId' in l:
+        for ex_line in self.line(blob):
+            if 'FullyQualifiedErrorId' in ex_line:
                 log = logging.getLogger('parsing_svc')
                 log.warning('This ability failed for some reason. Manually updating the link to report a failed state.')
                 return [PARSER_SIGNALS_FAILURE]

--- a/app/parsers/powershell.py
+++ b/app/parsers/powershell.py
@@ -1,0 +1,13 @@
+import logging
+from app.utility.base_parser import BaseParser
+
+
+class Parser(BaseParser):
+
+    def parse(self, blob):
+        for l in self.line(blob):
+            if 'FullyQualifiedErrorId' in l:
+                log = logging.getLogger('parsing_svc')
+                log.warning('This ability failed for some reason. Manually updating the link to report a failed state.')
+                return 418  # Universal Teapot error code
+        return []

--- a/app/parsers/powershell.py
+++ b/app/parsers/powershell.py
@@ -1,5 +1,5 @@
 import logging
-from app.utility.base_parser import BaseParser
+from app.utility.base_parser import BaseParser, PARSER_SIGNALS_FAILURE
 
 
 class Parser(BaseParser):
@@ -9,5 +9,5 @@ class Parser(BaseParser):
             if 'FullyQualifiedErrorId' in l:
                 log = logging.getLogger('parsing_svc')
                 log.warning('This ability failed for some reason. Manually updating the link to report a failed state.')
-                return 418  # Universal Teapot error code
+                return [PARSER_SIGNALS_FAILURE]
         return []


### PR DESCRIPTION
## Description

These changes make it possible for Caldera to parse powershell script returns from powershell abilities in Atomic to determine if they encountered an error. If an error was encountered, the link will be marked as unsuccessful. Requires associated CORE [changes](https://github.com/mitre/caldera/pull/2275).

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This has been tested in a AWS environment with Alice 2.0, as well as with the full battery of tests.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
