### PR TITLE
Avoid adding unnecessary semicolons when concatenating multi-line shell commands

### DIFF
--- a/app/atomic_svc.py
+++ b/app/atomic_svc.py
@@ -178,7 +178,13 @@ class AtomicService(BaseService):
         if executor == "cmd":
             return " && ".join(AtomicService._remove_dos_comment_lines(command_lines))
         else:
-            return "; ".join(AtomicService._remove_shell_comments(command_lines, executor))
+            return AtomicService._concatenate_shell_commands(AtomicService._remove_shell_comments(command_lines,
+                                                                                                  executor))
+
+    @staticmethod
+    def _concatenate_shell_commands(command_lines):
+        """Concatenate multiple shell command lines, making sure we don't add more than one ; character at the end."""
+        return '; '.join([re.sub(r';\s*$', '', cmd) for cmd in command_lines])
 
     @staticmethod
     def _remove_dos_comment_lines(command_lines):

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -130,3 +130,28 @@ class TestAtomicSvc:
         ])
         want = 'command1; command2; command3 ; command4;; command5'
         assert AtomicService._handle_multiline_commands(commands, 'sh') == want
+
+    def test_handle_multiline_command_shell_loop(self):
+        commands = '\n'.join([
+            'for port in {1..65535};',
+            '# comment',
+            ' # comment',
+            'do ',
+            'innerloopcommand;',
+            'innerloopcommand2',
+            'done'
+        ])
+        want = 'for port in {1..65535}; do innerloopcommand; innerloopcommand2; done'
+        assert AtomicService._handle_multiline_commands(commands, 'sh') == want
+
+    def test_handle_multiline_command_shell_ifthen(self):
+        commands = '\n'.join([
+            'if condition; then',
+            '# comment',
+            ' # comment',
+            'innercommand;',
+            'innercommand2;',
+            'fi'
+        ])
+        want = 'if condition; then innercommand; innercommand2; fi'
+        assert AtomicService._handle_multiline_commands(commands, 'sh') == want

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -117,3 +117,16 @@ class TestAtomicSvc:
                'echo "this is # not a comment"; echo "\'" can you \'"\' han`"dle "complex # quotes"; ' \
                'echo `"this is not actually a quote'
         assert AtomicService._handle_multiline_commands(commands, 'psh') == want
+
+    def test_handle_multiline_command_shell_semicolon(self):
+        commands = '\n'.join([
+            'command1',
+            '# comment',
+            ' # comment',
+            'command2; ',
+            'command3 ;',
+            'command4;;',
+            'command5'
+        ])
+        want = 'command1; command2; command3 ; command4;; command5'
+        assert AtomicService._handle_multiline_commands(commands, 'sh') == want


### PR DESCRIPTION
## Description
Avoid adding unnecessary semicolons when concatenating multi-line shell commands, such as when a command line ends in `then` or `do` (for if/else statements and for loops), or if it already ends in a semicolon.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Added pytest unit tests and tested running an affected atomic ability.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
