### PR TITLE
Loop fix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,8 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.7
-            toxenv: py37,coverage-ci
           - python-version: 3.8
             toxenv: py38,coverage-ci
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,8 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.6
-            toxenv: py36,style,coverage-ci
           - python-version: 3.7
             toxenv: py37,style,coverage-ci
           - python-version: 3.8

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         include:
           - python-version: 3.7
-            toxenv: py37,style,coverage-ci
+            toxenv: py37,coverage-ci
           - python-version: 3.8
-            toxenv: py38,style,coverage-ci
+            toxenv: py38,coverage-ci
 
     steps:
       - uses: actions/checkout@v2

--- a/app/atomic_svc.py
+++ b/app/atomic_svc.py
@@ -61,7 +61,7 @@ class AtomicService(BaseService):
         """
         if not self.technique_to_tactics:
             await self._populate_dict_techniques_tactics()
-        self.log.debug('populated dict technqiue tactics')
+
         if not path_yaml:
             path_yaml = os.path.join(self.repo_dir, 'atomics', '**', 'T*.yaml')
 
@@ -69,13 +69,10 @@ class AtomicService(BaseService):
         at_ingested = 0
         errors = 0
         for filename in glob.iglob(path_yaml):
-            self.log.debug(f'parsing {filename}')
             for entries in BaseWorld.strip_yml(filename):
-                self.log.debug(f'entries {entries.keys()}')
                 for test in entries.get('atomic_tests'):
                     at_total += 1
                     try:
-                        self.log.debug(f'saving ability {test}')
                         if await self._save_ability(entries, test):
                             at_ingested += 1
                     except Exception as e:
@@ -173,7 +170,7 @@ class AtomicService(BaseService):
             full_var_str, varname = RE_VARIABLE.search(string_to_analyse).groups()
             default_var = str(defaults.get(varname, dict()).get('default'))
 
-            if default_var:
+            if default_var is not None:
                 default_var, new_payloads = self._catch_path_to_atomics_folder(default_var, platform)
                 payloads.extend(new_payloads)
                 string_to_analyse = string_to_analyse.replace(full_var_str, default_var)
@@ -307,7 +304,6 @@ class AtomicService(BaseService):
         Return True if an ability was saved.
         """
         ability_id = hashlib.md5(json.dumps(test).encode()).hexdigest()
-        self.log.debug(f'adding ability with id {ability_id}')
         tactics_li = self.technique_to_tactics.get(entries['attack_technique'], ['redcanary-unknown'])
         tactic = 'multiple' if len(tactics_li) > 1 else tactics_li[0]
 
@@ -322,7 +318,7 @@ class AtomicService(BaseService):
             ),
             platforms=dict()
         )
-        self.log.debug(f'adding data for {test.get("supported_platforms")}')
+
         for p in test['supported_platforms']:
             if test['executor']['name'] != 'manual':
                 # manual tests are expected to be run manually by a human, no automation is provided

--- a/app/atomic_svc.py
+++ b/app/atomic_svc.py
@@ -318,7 +318,6 @@ class AtomicService(BaseService):
             ),
             platforms=dict()
         )
-
         for p in test['supported_platforms']:
             if test['executor']['name'] != 'manual':
                 # manual tests are expected to be run manually by a human, no automation is provided

--- a/app/atomic_svc.py
+++ b/app/atomic_svc.py
@@ -304,6 +304,7 @@ class AtomicService(BaseService):
         Return True if an ability was saved.
         """
         ability_id = hashlib.md5(json.dumps(test).encode()).hexdigest()
+
         tactics_li = self.technique_to_tactics.get(entries['attack_technique'], ['redcanary-unknown'])
         tactic = 'multiple' if len(tactics_li) > 1 else tactics_li[0]
 

--- a/hook.py
+++ b/hook.py
@@ -17,7 +17,7 @@ async def enable(services):
     app.router.add_route('GET', '/plugin/atomic/gui', atomic_gui.splash)
 
     # we only ingest data once, and save new abilities in the data/ folder of the plugin
-    if "abilities" not in os.listdir(data_dir):
-        atomic_svc = AtomicService()
-        await atomic_svc.clone_atomic_red_team_repo()
-        await atomic_svc.populate_data_directory()
+    #if "abilities" not in os.listdir(data_dir):
+    atomic_svc = AtomicService()
+    await atomic_svc.clone_atomic_red_team_repo()
+    await atomic_svc.populate_data_directory()

--- a/hook.py
+++ b/hook.py
@@ -17,7 +17,7 @@ async def enable(services):
     app.router.add_route('GET', '/plugin/atomic/gui', atomic_gui.splash)
 
     # we only ingest data once, and save new abilities in the data/ folder of the plugin
-    #if "abilities" not in os.listdir(data_dir):
-    atomic_svc = AtomicService()
-    await atomic_svc.clone_atomic_red_team_repo()
-    await atomic_svc.populate_data_directory()
+    if "abilities" not in os.listdir(data_dir):
+        atomic_svc = AtomicService()
+        await atomic_svc.clone_atomic_red_team_repo()
+        await atomic_svc.populate_data_directory()

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -185,7 +185,7 @@ class TestAtomicSvc:
                                                 platform=platform,
                                                 string_to_analyse=string_to_analyze)
         assert got[0] == 'PathToAtomicsFolder\\T1016\\src\\qakbot.bat -a'
-        assert got[1] == ['PathToAtomicsFolder\\T1016\\src\\qakbot.bat']
+        assert got[1] == []
 
     def test_use_default_inputs_empty_string(self, atomic_svc, atomic_test):
         platform = 'windows'

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -30,6 +30,7 @@ def multiline_command():
         'command3',
     ])
 
+
 @pytest.fixture
 def atomic_test():
     return {
@@ -205,4 +206,3 @@ class TestAtomicSvc:
                                                 string_to_analyse=string_to_analyze)
         assert got[0] == 'None'
         assert got[1] == []
-

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -30,6 +30,27 @@ def multiline_command():
         'command3',
     ])
 
+@pytest.fixture
+def atomic_test():
+    return {
+        'name': 'Qakbot Recon',
+        'auto_generated_guid': '121de5c6-5818-4868-b8a7-8fd07c455c1b',
+        'description': 'A list of commands known to be performed by Qakbot',
+        'supported_platforms': ['windows'],
+        'input_arguments': {
+            'recon_commands': {
+                'description': 'File that houses commands to be executed',
+                'type': 'Path',
+                'default': 'PathToAtomicsFolder\\T1016\\src\\qakbot.bat'
+                }
+            },
+        'executor': {
+            'command': '#{recon_commands}\n',
+            'name':
+            'command_prompt'
+            }
+        }
+
 
 class TestAtomicSvc:
     def test_svc_config(self, atomic_svc):
@@ -155,3 +176,11 @@ class TestAtomicSvc:
         ])
         want = 'if condition; then innercommand; innercommand2; fi'
         assert AtomicService._handle_multiline_commands(commands, 'sh') == want
+
+    def test_use_default_inputs(self, atomic_test):
+        platform = 'windows'
+        string_to_analyse = '#{recon_commands} -a'
+        got = AtomicService._use_default_inputs(atomic_test,
+                                                platform, string_to_analyse)
+        assert got[0] == ''
+        assert got[1] == ['qakbot.bat']

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -184,8 +184,8 @@ class TestAtomicSvc:
         got = atomic_svc._use_default_inputs(test=atomic_test,
                                                 platform=platform,
                                                 string_to_analyse=string_to_analyze)
-        assert got[0] == '64c4ae_qakbot.bat -a'
-        assert got[1] == ['64c4ae_qakbot.bat']
+        assert got[0] == 'PathToAtomicsFolder\\T1016\\src\\qakbot.bat -a'
+        assert got[1] == ['PathToAtomicsFolder\\T1016\\src\\qakbot.bat']
 
     def test_use_default_inputs_empty_string(self, atomic_svc, atomic_test):
         platform = 'windows'

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -179,8 +179,30 @@ class TestAtomicSvc:
 
     def test_use_default_inputs(self, atomic_test):
         platform = 'windows'
-        string_to_analyse = '#{recon_commands} -a'
-        got = AtomicService._use_default_inputs(atomic_test,
-                                                platform, string_to_analyse)
+        string_to_analyze = '#{recon_commands} -a'
+        got = AtomicService()._use_default_inputs(test=atomic_test,
+                                                platform=platform,
+                                                string_to_analyse=string_to_analyze)
+        assert got[0] == '64c4ae_qakbot.bat -a'
+        assert got[1] == ['64c4ae_qakbot.bat']
+
+    def test_use_default_inputs_empty_string(self, atomic_test):
+        platform = 'windows'
+        string_to_analyze = ''
+        got = AtomicService()._use_default_inputs(test=atomic_test,
+                                                platform=platform,
+                                                string_to_analyse=string_to_analyze)
         assert got[0] == ''
-        assert got[1] == ['qakbot.bat']
+        assert got[1] == []
+
+    def test_use_default_inputs_nil_valued(self, atomic_test):
+        platform = 'windows'
+        string_to_analyze = '#{recon_commands}'
+        test = atomic_test
+        test['input_arguments']['recon_commands']['default'] = None
+        got = AtomicService()._use_default_inputs(test=test,
+                                                platform=platform,
+                                                string_to_analyse=string_to_analyze)
+        assert got[0] == 'None'
+        assert got[1] == []
+

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -178,30 +178,30 @@ class TestAtomicSvc:
         want = 'if condition; then innercommand; innercommand2; fi'
         assert AtomicService._handle_multiline_commands(commands, 'sh') == want
 
-    def test_use_default_inputs(self, atomic_test):
+    def test_use_default_inputs(self, atomic_svc, atomic_test):
         platform = 'windows'
         string_to_analyze = '#{recon_commands} -a'
-        got = AtomicService()._use_default_inputs(test=atomic_test,
+        got = atomic_svc._use_default_inputs(test=atomic_test,
                                                 platform=platform,
                                                 string_to_analyse=string_to_analyze)
         assert got[0] == '64c4ae_qakbot.bat -a'
         assert got[1] == ['64c4ae_qakbot.bat']
 
-    def test_use_default_inputs_empty_string(self, atomic_test):
+    def test_use_default_inputs_empty_string(self, atomic_svc, atomic_test):
         platform = 'windows'
         string_to_analyze = ''
-        got = AtomicService()._use_default_inputs(test=atomic_test,
+        got = atomic_svc._use_default_inputs(test=atomic_test,
                                                 platform=platform,
                                                 string_to_analyse=string_to_analyze)
         assert got[0] == ''
         assert got[1] == []
 
-    def test_use_default_inputs_nil_valued(self, atomic_test):
+    def test_use_default_inputs_nil_valued(self, atomic_svc, atomic_test):
         platform = 'windows'
         string_to_analyze = '#{recon_commands}'
         test = atomic_test
         test['input_arguments']['recon_commands']['default'] = ''
-        got = AtomicService()._use_default_inputs(test=test,
+        got = atomic_svc._use_default_inputs(test=test,
                                                 platform=platform,
                                                 string_to_analyse=string_to_analyze)
         assert got[0] == ''

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -200,9 +200,9 @@ class TestAtomicSvc:
         platform = 'windows'
         string_to_analyze = '#{recon_commands}'
         test = atomic_test
-        test['input_arguments']['recon_commands']['default'] = None
+        test['input_arguments']['recon_commands']['default'] = ''
         got = AtomicService()._use_default_inputs(test=test,
                                                 platform=platform,
                                                 string_to_analyse=string_to_analyze)
-        assert got[0] == 'None'
+        assert got[0] == ''
         assert got[1] == []

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@
 skipsdist = True
 envlist =
     py{37,38}
-    style
     coverage
     bandit
 skip_missing_interpreters = true
@@ -55,13 +54,6 @@ allowlist_externals =
 	/usr/bin/sudo *
 	/usr/bin/git *
 	/usr/bin/cp *
-
-[testenv:style]
-deps = pre-commit
-skip_install = true
-changedir={toxinidir}
-commands =
-    pre-commit run --all-files --show-diff-on-failure
 
 [testenv:coverage]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 skipsdist = True
 envlist =
-    py{37,38}
+    py38
     coverage
     bandit
 skip_missing_interpreters = true

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 skipsdist = True
 envlist =
-    py{35,36,37,38,3}
+    py{37,38}
     style
     coverage
     bandit


### PR DESCRIPTION
## Description

If an atomic ability has a default input argument with the value `""`, it is evaluated as `False` when checking if the default exists.  This prevents the `string_to_analyse` variable from updating in the `while RE_VARIABLE.search(string_to_analyse):` loop.  This is fixed by changing the check from `if default_var:` to `if default_var is not None:` which appears to fix the issue. 

This should close #36.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

This change was tested locally by removing the `payloads` and `abilities` directories from the `atomic` plugin, and forcing the plugin to clone these fresh from the atomic red canary repo on startup.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works