### PR TITLE
fix 'checked_flags' variable in Parser module

### DIFF
--- a/app/parsers/atomic_powershell.py
+++ b/app/parsers/atomic_powershell.py
@@ -3,7 +3,7 @@ from app.utility.base_parser import BaseParser, PARSER_SIGNALS_FAILURE
 
 
 class Parser(BaseParser):
-    checked_flags = list('FullyQualifiedErrorId')
+    checked_flags = ['FullyQualifiedErrorId']
 
     def parse(self, blob):
         for ex_line in self.line(blob):


### PR DESCRIPTION
## Brief description

When running an Adversary Ability with a custom PowerShell command, the command runs successfully, but the Ability status is incorrectly set to "failed." This issue is caused by a logic problem in the atomic_powershell.py module.

Details:
- The module checks for the presence of the header FullyQualifiedErrorId in the response, but the logic is flawed.
- The module's logic involves splitting the FullyQualifiedErrorId string into individual letters and checking each letter against the headers.

## Description in depth

Ability output.

![002](https://github.com/mitre/atomic/assets/72035730/07561eef-25ab-49bd-9309-a5630bd858b6)
![003](https://github.com/mitre/atomic/assets/72035730/3de7d695-b0ef-465a-b926-cbbac2a5fd54)

The following is the Caldera output.

![001](https://github.com/mitre/atomic/assets/72035730/e8705bb4-8bbb-4280-b8eb-1935f6e2d263)

This problem is caused by the module *atomic_powershell.py* which, from what I understand, should check if the header *FullyQualifiedErrorId* is present.

It is declared a list called *checked_flags* that splits the 'FullyQualifiedErrorId' string letter by letter.

```python
checked_flags = list('FullyQualifiedErrorId')
```

The function *parse*, in the same module, is meant to check the response headers.
The code checks every header (*blob* variable) against every single letter contained in the *checked_flags* list. If the letter is present in the header string, it throws the error showed upon. The following is the code snippet that causes the error.

```python
def parse(self, blob):
        # for every header (blob string is splitted by newline)
        for ex_line in self.line(blob):
            if any(x in ex_line for x in self.checked_flags):
                # ...
                log.warning('This ability failed for some reason. Manually updating the link to report a failed state.')
```

## Proposed Fix

The issue with the checked_flags variable is addressed by changing the line:

```python
checked_flags = list('FullyQualifiedErrorId')
```

to:

```python
checked_flags = ['FullyQualifiedErrorId']
```
