### PR TITLE
Prefer Atomic Test UUID over calculated hash for Ability ID

### DIFF
--- a/app/atomic_svc.py
+++ b/app/atomic_svc.py
@@ -301,7 +301,7 @@ class AtomicService(BaseService):
         """
         Return True if an ability was saved.
         """
-        ability_id = hashlib.md5(json.dumps(test).encode()).hexdigest()
+        ability_id = test.get('auto_generated_guid') or hashlib.md5(json.dumps(test).encode()).hexdigest()
 
         tactics_li = self.technique_to_tactics.get(entries['attack_technique'], ['redcanary-unknown'])
         tactic = 'multiple' if len(tactics_li) > 1 else tactics_li[0]


### PR DESCRIPTION
## Description

Currently, the plugin calculates a md5 hash over the JSON serialized test definition for a given atomic test and then uses the hash value as the id for the plugin. While this is fine for static datasets, Atomic Tests every now and then receive updates. These updates cause the md5 hash to change an any reference in Caldera to break (e.g. abilities referenced from the stockpile plugin, check the debug output of Caldera for current examples).

This PR introduces a **breaking change** in the way how this plugin generates ability ids. Instead of calculating a hash over the test data, this plugin now prefers to use the auto-generated unique UUID that each test is assigned. This also affects how one references Atomic abilities in Plugins like stockpile but also custom in Adversaries created manually via API calls.

Context: when creating adversaries via manual API calls, one cannot just use the Atomic test uuid to link Abilities with a given Adversary but instead the custom hash value must be retrieved from the API beforehand. This makes it more tedious than I expected to reference Atomic tests in custom Adversaries. 

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
* caldera setup completes successfully
* all warnings from Stockpile plugin regarding missing abilities in adversaries are gone
* visual verification that especially the Stockpile adversaries contain only abilities which 'make sense' (see mitre/stockpile#579)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
