### PR TITLE
fix: skip whitespace-only lines in _concatenate_shell_commands to prevent stray semicolons (caldera#3097)

### DIFF
--- a/app/atomic_svc.py
+++ b/app/atomic_svc.py
@@ -189,10 +189,12 @@ class AtomicService(BaseService):
     @staticmethod
     def _concatenate_shell_commands(command_lines):
         """Concatenate multiple shell command lines. The ; character won't be added at the end of each command if the
-        command line ends in "then" or "do" or already ends with a ; character."""
+        command line ends in "then" or "do" or already ends with a ; character.
+        Whitespace-only lines are skipped to avoid producing stray ';' separators."""
         to_concat = []
-        num_lines = len(command_lines)
-        for index, cmd in enumerate(command_lines):
+        non_empty_lines = [cmd for cmd in command_lines if cmd.strip()]
+        num_lines = len(non_empty_lines)
+        for index, cmd in enumerate(non_empty_lines):
             to_concat.append(cmd)
             if re.search(r'do\s*$', cmd) or re.search(r'then\s*$', cmd) or re.search(r';\s*$', cmd):
                 if not re.search(r'\s+$', cmd):

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -183,10 +183,11 @@ class TestAtomicSvc:
         (ending with 'fi;') and the ability command must not produce a stray '; ' separator,
         which resulted in commands like 'fi;  ;  ip neighbour show'."""
         # Simulate the precmd built by _prepare_executor:
-        # dep_construct ends with 'fi;', then ' \n ' separates it from the ability command.
-        commands = 'if [ -x "$(command -v ip)" ]; then : ; else apt-get install iproute2 -y; fi;\n \n ip neighbour show'
+        # dep_construct ends with 'fi;', then '  \n  ' (two spaces) separates it from the
+        # ability command — matching the double-space pattern of the actual bug report.
+        commands = 'if [ -x "$(command -v ip)" ]; then : ; else apt-get install iproute2 -y; fi;\n  \n  ip neighbour show'
         result = AtomicService._handle_multiline_commands(commands, 'sh')
-        assert '; ;' not in result, f"Unexpected stray semicolon in: {result!r}"
+        assert ';  ;' not in result, f"Unexpected stray semicolon (double-space) in: {result!r}"
         assert 'ip neighbour show' in result
 
     def test_use_default_inputs(self, atomic_svc, atomic_test):

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import re
 import pytest
 
 from plugins.atomic.app.atomic_svc import AtomicService
@@ -187,7 +188,8 @@ class TestAtomicSvc:
         # ability command — matching the double-space pattern of the actual bug report.
         commands = 'if [ -x "$(command -v ip)" ]; then : ; else apt-get install iproute2 -y; fi;\n  \n  ip neighbour show'
         result = AtomicService._handle_multiline_commands(commands, 'sh')
-        assert ';  ;' not in result, f"Unexpected stray semicolon (double-space) in: {result!r}"
+        assert not re.search(r';\s+;', result), \
+            f"Unexpected consecutive semicolons with only whitespace between them in: {result!r}"
         assert 'ip neighbour show' in result
 
     def test_use_default_inputs(self, atomic_svc, atomic_test):

--- a/tests/test_atomic_svc.py
+++ b/tests/test_atomic_svc.py
@@ -178,6 +178,17 @@ class TestAtomicSvc:
         want = 'if condition; then innercommand; innercommand2; fi'
         assert AtomicService._handle_multiline_commands(commands, 'sh') == want
 
+    def test_handle_multiline_command_no_extra_semicolon_after_fi(self):
+        """Regression test for issue #3097: whitespace-only lines between prereq block
+        (ending with 'fi;') and the ability command must not produce a stray '; ' separator,
+        which resulted in commands like 'fi;  ;  ip neighbour show'."""
+        # Simulate the precmd built by _prepare_executor:
+        # dep_construct ends with 'fi;', then ' \n ' separates it from the ability command.
+        commands = 'if [ -x "$(command -v ip)" ]; then : ; else apt-get install iproute2 -y; fi;\n \n ip neighbour show'
+        result = AtomicService._handle_multiline_commands(commands, 'sh')
+        assert '; ;' not in result, f"Unexpected stray semicolon in: {result!r}"
+        assert 'ip neighbour show' in result
+
     def test_use_default_inputs(self, atomic_svc, atomic_test):
         platform = 'windows'
         string_to_analyze = '#{recon_commands} -a'


### PR DESCRIPTION
## Summary

- Fixes mitre/caldera#3097: extra semicolon in generated `ip neighbour` ability command.
- When a prerequisite block (ending with `fi;`) is combined with the ability command via `f"{dep_construct} \n {command}"`, a whitespace-only line between them was treated as a real command line in `_concatenate_shell_commands`, causing `'; '` to be appended after it.
- This produced broken shell syntax such as: `if [ -x "$(command -v ip)" ]; then : ; else apt-get install iproute2 -y; fi;  ;  ip neighbour show`
- Fix: filter out whitespace-only lines in `_concatenate_shell_commands` before concatenation.
- A regression test `test_handle_multiline_command_no_extra_semicolon_after_fi` is added.

## Test plan

- [x] All 16 existing + new tests pass: `python -m pytest plugins/atomic/tests/test_atomic_svc.py -v`
- [x] New regression test `test_handle_multiline_command_no_extra_semicolon_after_fi` verifies the fix
- [ ] Manually ingest an Atomic ability that uses a `sh` prerequisite (e.g. `ip neighbour show`) and confirm the generated command no longer contains `; ;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)