### PR TITLE
Add GitHub Actions workflows to match caldera core

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,19 @@
+name: Greetings
+
+on: [pull_request, issues]
+
+permissions:
+  contents: read
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/first-interaction@1d8459ca65b335265f1285568221e229d45a995e
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: 'Looks like your first issue -- we aim to respond to issues as quickly as possible. In the meantime, check out our documentation here: http://caldera.readthedocs.io/'
+        pr-message: 'Wohoo! Your first PR -- thanks for contributing!'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        stale-pr-message: 'This pull request is stale because it has had no activity for 60 days. Remove the stale label or comment or this will be closed in 60 days'
+        stale-issue-message: 'This issue is stale because it has had no activity for 60 days. Remove the stale label or comment or this will be closed in 60 days'
+        exempt-issue-labels: 'feature,keep'
+        days-before-stale: 60
+        days-before-close: 60

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,23 +1,42 @@
-name: Code Testing
+name: Code Quality
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.8
-            toxenv: py38,coverage-ci
+          - python-version: 3.10.9
+            toxenv: py310,coverage-ci
+          - python-version: 3.11
+            toxenv: py311,coverage-ci
+          - python-version: 3.12
+            toxenv: py312,coverage-ci
+          - python-version: 3.13
+            toxenv: py313,coverage-ci
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
## Summary

This PR updates and adds GitHub Actions workflows to match the caldera core repository.

### Changes:
- **testing.yml** (updated): Replaced outdated workflow that used `@v2` actions and Python 3.8 only. Now uses pinned SHA actions and tests against Python 3.10, 3.11, 3.12, and 3.13.
- **stale.yml** (new): Automatically marks issues and pull requests as stale after 60 days of inactivity, and closes them after another 60 days.
- **greetings.yml** (new): Greets first-time contributors when they open an issue or pull request.

All actions are pinned to specific SHAs for security.