### PR TITLE
fix: mark MD5 usage as non-security (B324)

### DIFF
--- a/app/atomic_svc.py
+++ b/app/atomic_svc.py
@@ -121,7 +121,7 @@ class AtomicService(BaseService):
         payload_name = os.path.basename(attachment_path)
         # to avoid collisions between payloads with the same name
         with open(attachment_path, 'rb') as f:
-            h = hashlib.md5(f.read()).hexdigest()
+            h = hashlib.md5(f.read(), usedforsecurity=False).hexdigest()
         payload_name = h[:PREFIX_HASH_LEN] + '_' + payload_name
         shutil.copyfile(attachment_path, os.path.join(self.payloads_dir, payload_name), follow_symlinks=False)
         return payload_name
@@ -301,7 +301,7 @@ class AtomicService(BaseService):
         """
         Return True if an ability was saved.
         """
-        ability_id = hashlib.md5(json.dumps(test).encode()).hexdigest()
+        ability_id = hashlib.md5(json.dumps(test).encode(), usedforsecurity=False).hexdigest()
 
         tactics_li = self.technique_to_tactics.get(entries['attack_technique'], ['redcanary-unknown'])
         tactic = 'multiple' if len(tactics_li) > 1 else tactics_li[0]


### PR DESCRIPTION
## Summary
Add `usedforsecurity=False` to `hashlib.md5()` calls that are used for non-cryptographic purposes.

## Changes
- `app/atomic_svc.py:124` — MD5 used for payload file deduplication (collision avoidance prefix)
- `app/atomic_svc.py:304` — MD5 used for ability ID generation from test content

Neither usage is for security/authentication. The `usedforsecurity=False` parameter (Python 3.9+) clarifies intent and suppresses security scanner warnings.

## Security Reference
- **B324**: Use of weak MD5 hash for security purposes

## Test plan
- [ ] Verify atomic plugin loads without errors
- [ ] Verify ability import still generates correct IDs
- [ ] Verify payload attachment deduplication still works