### PR TITLE
Fix copilot review feedback on security tests

### DIFF
--- a/tests/test_atomic_security.py
+++ b/tests/test_atomic_security.py
@@ -2,9 +2,10 @@ import ast
 import os
 
 import pytest
-import yaml
 
-PLUGIN_DIR = os.path.join(os.path.dirname(__file__), '..')
+yaml = pytest.importorskip("yaml")
+
+PLUGIN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 ATOMIC_SVC_PATH = os.path.join(PLUGIN_DIR, 'app', 'atomic_svc.py')
 PAYLOADS_DIR = os.path.join(PLUGIN_DIR, 'payloads')
 DATA_DIR = os.path.join(PLUGIN_DIR, 'data')
@@ -16,7 +17,7 @@ class TestAtomicSvcMD5Security:
 
     @pytest.fixture(autouse=True)
     def _load_source(self):
-        with open(ATOMIC_SVC_PATH, 'r') as f:
+        with open(ATOMIC_SVC_PATH, 'r', encoding='utf-8') as f:
             self.source = f.read()
         self.tree = ast.parse(self.source)
 
@@ -53,7 +54,7 @@ class TestAtomicSvcMD5Security:
         """
         md5_calls = self._find_md5_calls()
         for call_node in md5_calls:
-            keyword_names = [kw.arg for kw in call_node.keywords]
+            keyword_names = [kw.arg for kw in call_node.keywords if kw.arg is not None]
             has_usedforsecurity = 'usedforsecurity' in keyword_names
             if has_usedforsecurity:
                 for kw in call_node.keywords:
@@ -93,6 +94,11 @@ class TestAtomicAbilityYAML:
 
     def test_yaml_files_exist(self):
         """The atomic data directory should contain YAML test definitions."""
+        if not os.path.isdir(ATOMICS_DIR):
+            pytest.skip(
+                f"Atomics directory not found at {ATOMICS_DIR} — "
+                f"run 'git submodule update --init' to populate data"
+            )
         yaml_files = self._get_atomic_yaml_files()
         assert len(yaml_files) > 0, (
             f"No YAML files found in {ATOMICS_DIR} — "
@@ -103,7 +109,7 @@ class TestAtomicAbilityYAML:
         """All YAML files should parse without error."""
         yaml_files = self._get_atomic_yaml_files()
         for fpath in yaml_files:
-            with open(fpath, 'r') as f:
+            with open(fpath, 'r', encoding='utf-8') as f:
                 try:
                     data = yaml.safe_load(f)
                 except yaml.YAMLError as e:
@@ -122,7 +128,7 @@ class TestAtomicAbilityYAML:
             basename = os.path.basename(fpath)
             if not basename.startswith('T'):
                 continue
-            with open(fpath, 'r') as f:
+            with open(fpath, 'r', encoding='utf-8') as f:
                 data = yaml.safe_load(f)
             assert 'attack_technique' in data, (
                 f"Missing 'attack_technique' in {fpath}"


### PR DESCRIPTION
## Summary
- Normalize `PLUGIN_DIR` with `os.path.abspath()` for reliable path resolution
- Use `pytest.importorskip("yaml")` instead of bare `import yaml`
- Guard `ATOMICS_DIR` tests with `pytest.skip` when directory is missing
- Add `encoding='utf-8'` to all `open()` calls
- Handle `None` in `keyword.arg` during AST keyword scanning

## Test plan
- [ ] Run `pytest tests/test_atomic_security.py` to verify tests still pass
- [ ] Verify tests skip gracefully when atomics submodule is not initialized