### PR TITLE
Fix README Installation: document mitre/atomic, not the AtomicCaldera fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,28 +18,29 @@ Atomic-level detection validation
 
 ## Installation:
 
-1. Clone the repository to MITRE's Caldera "plugins" folder:
-`cd <path to caldera/plugins>`
-`git clone https://github.com/xenoscr/atomiccaldera.git`
-2. Change directories:
-`cd atomiccaldera`
-3. Install required Python modules:
-`pip install -r requirements.txt`
-4. Clone the Red Canary Atomic Red Team repository:
-`git clone https://github.com/redcanaryco/atomic-red-team.git`
-5. Clone the MITRE CTI repository:
-`git clone https://github.com/mitre/cti.git`
-6. Edit the `conf/artconf.yml` file to update the paths to point to your Atomic Red Team and CTI repositories.
-7. Edit Caldera's `local.yml` file and add `atomiccaldera` to the plugins section.
+The Atomic plugin ships with CALDERA as a default plugin (a git submodule under
+`plugins/atomic`). To add it manually:
+
+1. Clone this repository into CALDERA's `plugins` folder:
+`cd <path to caldera>/plugins`
+`git clone https://github.com/mitre/atomic.git`
+2. Enable the plugin by adding `- atomic` to the `plugins:` list in CALDERA's
+`conf/local.yml` (or `conf/default.yml`).
+3. Restart CALDERA.
+
+On first load the plugin automatically clones Red Canary's Atomic Red Team
+repository into `plugins/atomic/data/atomic-red-team` and imports the tests as
+abilities — no manual cloning, requirements file, or path configuration is
+required. The ATT&CK technique-to-tactic mapping is read from the
+`enterprise-attack.json` file bundled inside that same repository, so no separate
+CTI repository is needed. (This first import takes a while; see "Getting Started"
+below.)
 
 ## Dependencies/Requirements:
 
-1. Python 3.8+ with the following libraries installed:
-- PyYAML - https://pyyaml.org/wiki/PyYAML
-- STIX2 - https://github.com/oasis-open/cti-python-stix2
-2. Atomic-Caldera requires the following repositories be stored locally somewhere:
-- https://github.com/redcanaryco/atomic-red-team
-- https://github.com/mitre/cti
+- `git` available on the PATH (used to clone the Atomic Red Team repository).
+- Python dependencies are provided by CALDERA core (e.g. PyYAML); the plugin has
+no separate requirements file or install step.
 
 ## Getting Started:
 


### PR DESCRIPTION
## Problem

The README's recent rewrite (2026-04-27 → 04-30) reintroduced setup instructions for the old third-party **`xenoscr/atomiccaldera`** project rather than this plugin (`mitre/atomic`). Every step in the Installation/Dependencies sections was inaccurate. Verified against the actual code:

| README said | Reality in `mitre/atomic` |
|---|---|
| clone `xenoscr/atomiccaldera`, add `atomiccaldera` to plugins | should be `mitre/atomic` → `plugins/atomic`, enable `atomic` |
| `pip install -r requirements.txt` | **no `requirements.txt` exists** in the repo |
| manually `git clone redcanaryco/atomic-red-team` | done **automatically** on first enable — `clone_atomic_red_team_repo()` (`app/atomic_svc.py:42-52`) |
| `git clone mitre/cti` + STIX2 dep | **not used**; `enterprise-attack.json` is bundled inside the atomic-red-team repo and read directly (`app/atomic_svc.py:111`). `stix2` is never imported |
| `edit conf/artconf.yml` | **no `conf/` dir, no `artconf` reference** anywhere in code |

## Change

- Rewrites **Installation** to the standard CALDERA plugin flow: clone into `plugins/`, enable in `conf/local.yml`, restart — data is auto-fetched on first load.
- Trims **Dependencies/Requirements** to what's actually needed (`git` on PATH; Python deps from CALDERA core).
- Leaves Overview, Known Limitations, Getting Started, and the Additional Note untouched.

## Validation

- `grep -rni artconf` → only the README; no `conf/` directory.
- `grep -rni mitre/cti / cti.git` → only the README; code reads bundled `enterprise-attack.json`.
- `enterprise-attack.json` confirmed present in `redcanaryco/atomic-red-team/atomic_red_team/` (46 MB).
- `stix2` not imported anywhere; no `requirements.txt` in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)