### PR TITLE
README: drop AtomicCaldera link, move Known Limitations after Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,9 @@
 The Atomic plugin converts Red Canary’s Atomic Red Team tests from their open-source GitHub repository into CALDERA abilities for granular ATT&CK simulation.
 
 - [Atomic Red Team](https://github.com/redcanaryco/atomic-red-team)
-- [AtomicCaldera](https://github.com/xenoscr/atomiccaldera)
 
 ### Context:
 Atomic-level detection validation
-
-### Known Limitations:
-- ART tests only specify techniques they address. This plugin creates a mapping and import abilities under the corresponding tactic. Yet sometimes multiple tactics are a match, and we do not know which one the test addresses. This will be fixed in the future thanks to the ATT&CK sub-techniques. As of now, we use a new tactic category called "multiple".
-- When a command/cleanup expands over multiple lines with one of them being a comment, it messes up the whole command/cleanup (as we reduce multiple lines into one with semi-colons).
-- ART tests are not full adversary attack chains/ emulations.
-- Some ART tests are incomplete.
 
 ## Installation:
 
@@ -75,7 +68,12 @@ If you wish to delete everything that has been imported and wish to start over, 
  
 After clicking yes, it will then take some time for the abilities to complete reloading. NOTE: It is necessary to restart Caldera to view the new abilities. At the moment there is no way to force Chain to reload its database from the GUI.
 
-### Additional Note
-- When importing tests from Atomic Red Team, this plugin also catches `$PathToAtomicsFolder` usages pointing to an existing file.  It then imports the files as payloads and fixes path usages. Note other usages are not handled. If a path with `$PathToAtomicsFolder` points to an existing directory or an unexisting file, we will not process it any further and ingest it "as it is". Examples of such usages below:
-- https://github.com/redcanaryco/atomic-red-team/blob/a956d4640f9186a7bd36d16a63f6d39433af5f1d/atomics/T1022/T1022.yaml#L99
-- https://github.com/redcanaryco/atomic-red-team/blob/ab0b391ac0d7b18f25cb17adb330309f92fa94e6/atomics/T1056/T1056.yaml#L24
+## Known Limitations:
+
+- ART tests only specify techniques they address. This plugin creates a mapping and import abilities under the corresponding tactic. Yet sometimes multiple tactics are a match, and we do not know which one the test addresses. This will be fixed in the future thanks to the ATT&CK sub-techniques. As of now, we use a new tactic category called "multiple".
+- When a command/cleanup expands over multiple lines with one of them being a comment, it messes up the whole command/cleanup (as we reduce multiple lines into one with semi-colons).
+- ART tests are not full adversary attack chains/ emulations.
+- Some ART tests are incomplete.
+- When importing tests from Atomic Red Team, this plugin also catches `$PathToAtomicsFolder` usages pointing to an existing file. It then imports the files as payloads and fixes path usages. Note other usages are not handled. If a path with `$PathToAtomicsFolder` points to an existing directory or an unexisting file, we will not process it any further and ingest it "as it is". Examples of such usages below:
+  - https://github.com/redcanaryco/atomic-red-team/blob/a956d4640f9186a7bd36d16a63f6d39433af5f1d/atomics/T1022/T1022.yaml#L99
+  - https://github.com/redcanaryco/atomic-red-team/blob/ab0b391ac0d7b18f25cb17adb330309f92fa94e6/atomics/T1056/T1056.yaml#L24


### PR DESCRIPTION
## Summary
Cleans up the Atomic plugin README structure:

- **Removed** the stale `xenoscr/atomiccaldera` link from the Overview (this plugin is `mitre/atomic`, not the third-party fork).
- **Moved** *Known Limitations* out of the Overview and into its own top-level section, placed after *Getting Started* where it reads more naturally.
- **Folded** the former *Additional Note* (`$PathToAtomicsFolder` handling) into *Known Limitations* as the final bullet, with the two example URLs as nested sub-bullets.

No content was lost — only the broken fork link was dropped. Section order is now: Overview → Context → Installation → Dependencies/Requirements → Getting Started → Known Limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)